### PR TITLE
FIX: Display of ResultCodes in error message

### DIFF
--- a/WNet.Connection/NetworkConnection.cs
+++ b/WNet.Connection/NetworkConnection.cs
@@ -35,7 +35,7 @@ namespace WNet.Connection
             if (connectResultCode != 0)
             {
                 var message = $"Error when connect to remote share. networkName: {networkName}."
-                    + "WNetAddConnection2: {connectResultCode}. WNetCancelConnection2: {cancelResultCode}";
+                    + $" WNetAddConnection2: {connectResultCode}. WNetCancelConnection2: {cancelResultCode}";
                 throw new Win32Exception(connectResultCode, message);
             }
         }


### PR DESCRIPTION
To fix error message displayed as:
"Error when connect to remote share. networkName: //xx.xx.xx.xx/Share.WNetAddConnection2: {connectResultCode}. WNetCancelConnection2: {cancelResultCode}"